### PR TITLE
fix: fix cors config validation

### DIFF
--- a/server/api/dto/admin/request/cors.go
+++ b/server/api/dto/admin/request/cors.go
@@ -8,7 +8,7 @@ import (
 
 type CreateCorsDto struct {
 	AllowedOrigins      []string `json:"allowed_origins" validate:"required,min=1"`
-	AllowUnsafeWildcard bool     `json:"allow_unsafe_wildcard" validate:"required,boolean"`
+	AllowUnsafeWildcard *bool    `json:"allow_unsafe_wildcard" validate:"required,boolean"`
 }
 
 func (dto *CreateCorsDto) ToModel(config models.Config) models.Cors {
@@ -32,7 +32,7 @@ func (dto *CreateCorsDto) ToModel(config models.Config) models.Cors {
 	cors := models.Cors{
 		ID:          corsId,
 		ConfigID:    config.ID,
-		AllowUnsafe: dto.AllowUnsafeWildcard,
+		AllowUnsafe: *dto.AllowUnsafeWildcard,
 		Origins:     origins,
 		CreatedAt:   now,
 		UpdatedAt:   now,


### PR DESCRIPTION
Use a pointer for `allow_unsafe_wildcard` otherwise the config can not be updated when `allow_unsafe_wildcard: false`. Because the validation library interprets the value `false` as not present (for more info see [here](https://github.com/go-playground/validator/issues/713)). 