### PR TITLE
fix: delete correct secret

### DIFF
--- a/server/api/handler/admin/secrets.go
+++ b/server/api/handler/admin/secrets.go
@@ -126,7 +126,8 @@ func (s *SecretsHandler) removeKey(ctx echo.Context, isApiKey bool) error {
 	var foundSecret *models.Secret
 	for _, secret := range tenant.Config.Secrets {
 		if secret.ID == secretId && secret.IsAPISecret == isApiKey {
-			foundSecret = &secret
+			s := secret
+			foundSecret = &s
 		}
 	}
 


### PR DESCRIPTION
When deleting a secret it is possible to delete a wrong secret due to: `Implicit memory aliasing in for loop` when searching for the correct secret.