### PR TITLE
feat: only create API key when requested

### DIFF
--- a/server/api/dto/admin/request/tenant.go
+++ b/server/api/dto/admin/request/tenant.go
@@ -7,8 +7,9 @@ import (
 )
 
 type CreateTenantDto struct {
-	DisplayName string          `json:"display_name" validate:"required"`
-	Config      CreateConfigDto `json:"config" validate:"required"`
+	DisplayName  string          `json:"display_name" validate:"required"`
+	Config       CreateConfigDto `json:"config" validate:"required"`
+	CreateApiKey bool            `json:"create_api_key"`
 }
 
 func (dto *CreateTenantDto) ToModel() models.Tenant {

--- a/server/api/dto/admin/response/secrets.go
+++ b/server/api/dto/admin/response/secrets.go
@@ -15,8 +15,11 @@ type SecretResponseDto struct {
 
 type SecretResponseListDto = []SecretResponseDto
 
-func ToSecretResponse(secret *models.Secret) SecretResponseDto {
-	return SecretResponseDto{
+func ToSecretResponse(secret *models.Secret) *SecretResponseDto {
+	if secret == nil {
+		return nil
+	}
+	return &SecretResponseDto{
 		Id:        secret.ID,
 		Name:      secret.Name,
 		Secret:    secret.Key,

--- a/server/api/dto/admin/response/tenant.go
+++ b/server/api/dto/admin/response/tenant.go
@@ -32,8 +32,8 @@ func ToGetTenantResponse(tenant *models.Tenant) GetTenantResponse {
 }
 
 type CreateTenantResponse struct {
-	Id     uuid.UUID         `json:"id"`
-	ApiKey SecretResponseDto `json:"api_key"`
+	Id     uuid.UUID          `json:"id"`
+	ApiKey *SecretResponseDto `json:"api_key,omitempty"`
 }
 
 func ToCreateTenantResponse(tenant *models.Tenant, apiKey *models.Secret) CreateTenantResponse {

--- a/server/api/services/admin/secret_service.go
+++ b/server/api/services/admin/secret_service.go
@@ -37,7 +37,7 @@ func (ses *secretService) List(isApiSecret bool) response.SecretResponseListDto 
 	secrets := make(response.SecretResponseListDto, 0)
 	for _, secret := range ses.tenant.Config.Secrets {
 		if secret.IsAPISecret == isApiSecret {
-			secrets = append(secrets, response.ToSecretResponse(&secret))
+			secrets = append(secrets, *response.ToSecretResponse(&secret))
 		}
 	}
 
@@ -58,7 +58,7 @@ func (ses *secretService) Create(dto request.CreateSecretDto, isApiSecret bool) 
 	}
 
 	responseDto := response.ToSecretResponse(secret)
-	return &responseDto, nil
+	return responseDto, nil
 }
 
 func (ses *secretService) Remove(dto request.RemoveSecretDto, isApiKey bool) error {

--- a/server/api/services/admin/tenant_service.go
+++ b/server/api/services/admin/tenant_service.go
@@ -105,10 +105,13 @@ func (ts *tenantService) Create(dto request.CreateTenantDto) (*response.CreateTe
 		&relyingPartyModel,
 	)
 
-	apiSecretModel, err := ts.createSecret("Initial API Key", configModel.ID, true)
-	if err != nil {
-		ts.logger.Error(err)
-		return nil, fmt.Errorf("unable to create new api key: %w", err)
+	var apiSecretModel *models.Secret = nil
+	if dto.CreateApiKey {
+		apiSecretModel, err = ts.createSecret("Initial API Key", configModel.ID, true)
+		if err != nil {
+			ts.logger.Error(err)
+			return nil, fmt.Errorf("unable to create new api key: %w", err)
+		}
 	}
 
 	jwkSecretModel, err := ts.createSecret("Initial JWK Key", configModel.ID, false)


### PR DESCRIPTION
Only create a API key at tenant creation when it is requested. This way, when someone creates a new tenant at our console does not have already an API key he can't use, because we do not show the secret when the tenant was created.