### PR TITLE
fix(migration): change secrets key column to string

### DIFF
--- a/deploy/docker-compose/backend-mariadb.yaml
+++ b/deploy/docker-compose/backend-mariadb.yaml
@@ -1,0 +1,58 @@
+version: '3.9'
+services:
+  passkey-migrate:
+    build: ../../server
+    volumes:
+      - type: bind
+        source: ./config-mariadb.yaml
+        target: /etc/config/config.yaml
+    command: --config /etc/config/config.yaml migrate up
+    restart: on-failure
+    depends_on:
+      mariadbd:
+        condition: service_healthy
+    networks:
+      - intranet
+  passkey-server:
+    build: ../../server
+    volumes:
+      - type: bind
+        source: ./config-mariadb.yaml
+        target: /etc/config/config.yaml
+    command: --config /etc/config/config.yaml serve all
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+    restart: unless-stopped
+    depends_on:
+      passkey-migrate:
+        condition: service_completed_successfully
+    networks:
+      - intranet
+  mariadbd:
+    image: mariadb:11
+    ports:
+      - "3306:3306"
+    environment:
+      - MARIADB_USER=hanko
+      - MARIADB_PASSWORD=hanko
+      - MARIADB_DATABASE=passkey
+      - MARIADB_RANDOM_ROOT_PASSWORD=true
+    healthcheck:
+      interval: 30s
+      retries: 3
+      test:
+          [
+          "CMD",
+          "healthcheck.sh",
+          "--su-mysql",
+          "--connect",
+          "--innodb_initialized"
+          ]
+      timeout: 30s
+      start_period: 30s
+    networks:
+      - intranet
+
+networks:
+  intranet:

--- a/deploy/docker-compose/config-mariadb.yaml
+++ b/deploy/docker-compose/config-mariadb.yaml
@@ -1,0 +1,7 @@
+database:
+  database: passkey
+  dialect: mysql
+  host: mariadbd
+  port: 3306
+  user: hanko
+  password: hanko

--- a/server/persistence/migrations/20231107191413_create_secrets.up.fizz
+++ b/server/persistence/migrations/20231107191413_create_secrets.up.fizz
@@ -1,7 +1,7 @@
 create_table("secrets") {
 	t.Column("id", "uuid", {primary: true})
 	t.Column("name", "string", {})
-	t.Column("key", "text", { "null": false })
+	t.Column("key", "string", { "null": false, "size": 200 })
 	t.Column("is_api_secret", "boolean", { "default": true })
 	t.Column("config_id", "uuid", { "null": false })
 


### PR DESCRIPTION
Change column type to string with max length 200 for keys in secrets. Change Reason: MySQL cannot work with text fields in unique keys as they have no specified length

Tested with docker image `mariadb:11`

Closes: #43