### PR TITLE
fix(docs): add create_api_key param

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -119,7 +119,7 @@ To apply the migrations, run:
 ### Create Tenant
 
 Now you need to create a tenant. For this you can import our [admin OpenAPI specification](../spec/passkey-server-admin.yaml)
-into Postman or Insomnia or use the following curl command:
+into Postman, Insomnia or use the following curl command:
 
 ```shell
 curl --location 'http://<YOUR DOMAIN>:8001/tenants' \
@@ -144,11 +144,13 @@ curl --location 'http://<YOUR DOMAIN>:8001/tenants' \
       },
       "timeout": 60000,
       "user_verification": "preferred"
-    }
+    },
+    "create_api_key": true
   }
 }'
 ```
-> **Note**: The result of the curl command will contain your **tenant id** (Field: `id`) and your **API key** (Field: `api_key.secret`)
+> **Note**: The result of the curl command will contain your **tenant id** (Field: `id`) and your **API key** (Field: `api_key.secret`). 
+> If you want to skip the api key creation, remove the `create_api_key` parameter from the body. 
 
 Let us dissect the command to show how to configure the tenant for your use case.
 

--- a/spec/passkey-server-admin.yaml
+++ b/spec/passkey-server-admin.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: '1.0'
+  version: '1.1'
   title: passkey-server-admin
   summary: Admin API for Passkey Server
   description: 'ADmin API for Hanko Passkey Server. Allows creation and configiration of tenants and api keys, '
@@ -508,6 +508,8 @@ components:
                 type: string
               config:
                 $ref: '#/components/schemas/config'
+              create_api_key:
+                type: boolean
             required:
               - display_name
     update_tenant:
@@ -580,7 +582,6 @@ components:
           $ref: '#/components/schemas/secret'
       required:
         - id
-        - api_key
     secret:
       type: object
       title: secret


### PR DESCRIPTION
* add `create_api_key` param to create_tenant in admin openapi spec
* add `create_api_key` to curl body in docs
* add note that you can remove the `create_api_key` from curl body

Closes: #34