### PR TITLE
feat(webauthn): allow optional user_id for login/initialize

### DIFF
--- a/server/api/dto/intern/webauthn_session_data.go
+++ b/server/api/dto/intern/webauthn_session_data.go
@@ -33,7 +33,7 @@ func WebauthnSessionDataFromModel(data *models.WebauthnSessionData) *webauthn.Se
 	}
 }
 
-func WebauthnSessionDataToModel(data *webauthn.SessionData, tenantId uuid.UUID, operation models.Operation) *models.WebauthnSessionData {
+func WebauthnSessionDataToModel(data *webauthn.SessionData, tenantId uuid.UUID, operation models.Operation, isDiscoverable bool) *models.WebauthnSessionData {
 	id, _ := uuid.NewV4()
 	now := time.Now()
 
@@ -62,5 +62,6 @@ func WebauthnSessionDataToModel(data *webauthn.SessionData, tenantId uuid.UUID, 
 		AllowedCredentials: allowedCredentials,
 		ExpiresAt:          nulls.NewTime(data.Expires),
 		TenantID:           tenantId,
+		IsDiscoverable:     isDiscoverable,
 	}
 }

--- a/server/api/dto/request/requests.go
+++ b/server/api/dto/request/requests.go
@@ -30,7 +30,7 @@ type UpdateCredentialsDto struct {
 }
 
 type WebauthnRequests interface {
-	InitRegistrationDto | InitTransactionDto
+	InitRegistrationDto | InitTransactionDto | InitLoginDto
 }
 
 type InitRegistrationDto struct {
@@ -90,4 +90,8 @@ func (initTransaction *InitTransactionDto) ToModel() (*models.Transaction, error
 		CreatedAt: now,
 		UpdatedAt: now,
 	}, nil
+}
+
+type InitLoginDto struct {
+	UserId *string `json:"user_id" validate:"omitempty,min=1"`
 }

--- a/server/api/handler/login.go
+++ b/server/api/handler/login.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/labstack/echo/v4"
+	"github.com/teamhanko/passkey-server/api/dto/request"
 	"github.com/teamhanko/passkey-server/api/dto/response"
 	"github.com/teamhanko/passkey-server/api/helper"
 	"github.com/teamhanko/passkey-server/api/services"
@@ -33,6 +34,11 @@ func (lh *loginHandler) Init(ctx echo.Context) error {
 		return err
 	}
 
+	dto, err := BindAndValidateRequest[request.InitLoginDto](ctx)
+	if err != nil {
+		return err
+	}
+
 	return lh.persister.GetConnection().Transaction(func(tx *pop.Connection) error {
 		userPersister := lh.persister.GetWebauthnUserPersister(tx)
 		sessionPersister := lh.persister.GetWebauthnSessionDataPersister(tx)
@@ -42,6 +48,7 @@ func (lh *loginHandler) Init(ctx echo.Context) error {
 			Ctx:                 ctx,
 			Tenant:              *h.Tenant,
 			WebauthnClient:      *h.Webauthn,
+			UserId:              dto.UserId,
 			UserPersister:       userPersister,
 			SessionPersister:    sessionPersister,
 			CredentialPersister: credentialPersister,

--- a/server/api/services/registration_service.go
+++ b/server/api/services/registration_service.go
@@ -64,7 +64,7 @@ func (rs *registrationService) Initialize(user *models.WebauthnUser) (*protocol.
 		return nil, internalUser.UserId, err
 	}
 
-	err = rs.sessionDataPersister.Create(*intern.WebauthnSessionDataToModel(sessionData, rs.tenant.ID, models.WebauthnOperationRegistration))
+	err = rs.sessionDataPersister.Create(*intern.WebauthnSessionDataToModel(sessionData, rs.tenant.ID, models.WebauthnOperationRegistration, false))
 	if err != nil {
 		return nil, internalUser.UserId, err
 	}

--- a/server/api/services/transaction_service.go
+++ b/server/api/services/transaction_service.go
@@ -92,7 +92,7 @@ func (ts *transactionService) Initialize(userId string, transaction *models.Tran
 		return nil, err
 	}
 
-	err = ts.sessionDataPersister.Create(*intern.WebauthnSessionDataToModel(sessionData, ts.tenant.ID, models.WebauthnOperationTransaction))
+	err = ts.sessionDataPersister.Create(*intern.WebauthnSessionDataToModel(sessionData, ts.tenant.ID, models.WebauthnOperationTransaction, false))
 	if err != nil {
 		ts.logger.Error(err)
 		return nil, err

--- a/server/api/services/webauthn_service.go
+++ b/server/api/services/webauthn_service.go
@@ -31,6 +31,7 @@ type WebauthnServiceCreateParams struct {
 	WebauthnClient        webauthn.WebAuthn
 	Generator             jwt.Generator
 	AuthenticatorMetadata mapper.AuthenticatorMetadata
+	UserId                *string
 
 	UserPersister       persisters.WebauthnUserPersister
 	SessionPersister    persisters.WebauthnSessionDataPersister

--- a/server/persistence/migrations/20240226103525_add_discoverable_to_sessiondata.down.fizz
+++ b/server/persistence/migrations/20240226103525_add_discoverable_to_sessiondata.down.fizz
@@ -1,0 +1,1 @@
+drop_column("webauthn_session_data", "is_discoverable")

--- a/server/persistence/migrations/20240226103525_add_discoverable_to_sessiondata.up.fizz
+++ b/server/persistence/migrations/20240226103525_add_discoverable_to_sessiondata.up.fizz
@@ -1,0 +1,1 @@
+add_column("webauthn_session_data", "is_discoverable", "bool", { "default": true })

--- a/server/persistence/models/webauthn_session_data.go
+++ b/server/persistence/models/webauthn_session_data.go
@@ -29,13 +29,14 @@ type WebauthnSessionData struct {
 	Operation          Operation                              `db:"operation"`
 	AllowedCredentials []WebauthnSessionDataAllowedCredential `has_many:"webauthn_session_data_allowed_credentials"`
 	ExpiresAt          nulls.Time                             `db:"expires_at"`
+	IsDiscoverable     bool                                   `db:"is_discoverable"`
 
 	TenantID uuid.UUID `db:"tenant_id"`
 	Tenant   *Tenant   `belongs_to:"tenants"`
 }
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
-func (sd *WebauthnSessionData) Validate(tx *pop.Connection) (*validate.Errors, error) {
+func (sd *WebauthnSessionData) Validate(_ *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.UUIDIsPresent{Name: "ID", Field: sd.ID},
 		&validators.StringIsPresent{Name: "Challenge", Field: sd.Challenge},

--- a/spec/passkey-server.yaml
+++ b/spec/passkey-server.yaml
@@ -176,6 +176,8 @@ paths:
       operationId: post-login-initialize
       parameters:
         - $ref: '#/components/parameters/tenant_id'
+      requestBody:
+        $ref: '#/components/requestBodies/post-login-initialize'
       responses:
         '200':
           $ref: '#/components/responses/post-login-initialize'
@@ -428,6 +430,16 @@ components:
               - user_id
               - transaction_id
               - transaction_data
+    post-login-initialize:
+      description: Body for login/initialize
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: string
+                description: optional
   responses:
     get-credentials:
       description: Example response


### PR DESCRIPTION
* add login init dto with user_id as optional param
* extend service to switch to BeginLogin /ValidateLogin when user_id was given
* extend database to persist login state in sessiondata for login/finalize
* extend openapi spec to reflect optional user_id parameter for login/initialize

Closes: #33