### PR TITLE
Check whether `CredentialsProvider` has a `default` field

### DIFF
--- a/packages/js/passkeys-next-auth-provider/index.ts
+++ b/packages/js/passkeys-next-auth-provider/index.ts
@@ -46,7 +46,11 @@ export function PasskeyProvider({
 	const JWKS = createRemoteJWKSet(url);
 
 	// TODO call normally when this is fixed: https://github.com/nextauthjs/next-auth/issues/572
-	return ((CredentialsProvider as any).default as typeof CredentialsProvider)({
+	return (
+		('default' in CredentialsProvider
+			? (CredentialsProvider as any).default
+			: CredentialsProvider) as typeof CredentialsProvider
+	)({
 		id,
 		credentials: {
 			/**


### PR DESCRIPTION
This is breaking for our usage, because `CredentialsProvider.default` is undefined.

I've encountered this `default` issue myself with a few libraries, where the presence of `default` depends on what I'm running the code with (e.g. `tsx` vs `bun`), and this `'default' in FooBar` check has worked well for me!