### PR TITLE
fix: store mfa default values when missing

### DIFF
--- a/server/api/middleware/webauthn.go
+++ b/server/api/middleware/webauthn.go
@@ -44,16 +44,14 @@ func WebauthnMiddleware(persister persistence.Persister) echo.MiddlewareFunc {
 }
 
 func setWebauthnClientCtx(ctx echo.Context, cfg models.Config, persister persistence.Persister) error {
-	var passkeyConfig models.WebauthnConfig
-
 	err := createPasskeyClient(ctx, cfg.WebauthnConfig)
 	if err != nil {
 		ctx.Logger().Error(err)
 		return err
 	}
 
-	if cfg.MfaConfig == nil {
-		cfg.MfaConfig, err = createDefaultMfaConfig(persister, passkeyConfig)
+	if cfg.MfaConfig == nil || cfg.MfaConfig.ID == uuid.Nil {
+		cfg.MfaConfig, err = createDefaultMfaConfig(persister, cfg.WebauthnConfig)
 		if err != nil {
 			ctx.Logger().Error(err)
 			return err


### PR DESCRIPTION
MFA config is not stored because the check if it exists is wrong. This PR fixes it.