### PR TITLE
fix: set an empty json body if no body is set

### DIFF
--- a/server/api/handler/webauthn.go
+++ b/server/api/handler/webauthn.go
@@ -8,7 +8,9 @@ import (
 	auditlog "github.com/teamhanko/passkey-server/audit_log"
 	"github.com/teamhanko/passkey-server/persistence"
 	"github.com/teamhanko/passkey-server/persistence/models"
+	"io"
 	"net/http"
+	"strings"
 )
 
 type WebauthnHandler interface {
@@ -49,6 +51,11 @@ func (w *webauthnHandler) handleError(logger auditlog.Logger, logType models.Aud
 
 func BindAndValidateRequest[I request.CredentialRequests | request.WebauthnRequests](ctx echo.Context) (*I, error) {
 	var requestDto I
+
+	if ctx.Request().ContentLength <= 0 {
+		ctx.Request().Body = io.NopCloser(strings.NewReader("{}"))
+	}
+
 	err := ctx.Bind(&requestDto)
 	if err != nil {
 		ctx.Logger().Error(err)


### PR DESCRIPTION
If no body is set it can be that the server returns an `EOF` error. So this PR sets the body to an empty json object if no body was send.