### PR TITLE
docs: fixed incorrect create tenant request body in server README.md

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -146,9 +146,9 @@ curl --location 'http://<YOUR DOMAIN>:8001/tenants' \
       "user_verification": "preferred",
       "attestation_preference": "none",
       "resident_key_requirement": "required"
-    },
-    "create_api_key": true
-  }
+    }
+  },
+  "create_api_key": true
 }'
 ```
 > **Note**: The result of the curl command will contain your **tenant id** (Field: `id`) and your **API key** (Field: `api_key.secret`). 


### PR DESCRIPTION
## Context

As per the DTO definition for `POST /tenants` API [defined here](https://github.com/teamhanko/passkeys/blob/d544a1e83ef4a1a4c5fb803485a548b76d6c6354/server/api/dto/admin/request/tenant.go#L12),
`create_api_key` property is defined at the root of the JSON request body not within the `config` property.

The request example to create a new tenant puts `create_api_key` within the `config` property as [defined here](https://github.com/teamhanko/passkeys/blob/d544a1e83ef4a1a4c5fb803485a548b76d6c6354/server/README.md?plain=1#L149-L151) which is incorrect.

## Changes

- Update the example request to align with the definition of the DTO.