### PR TITLE
ci: make workflows ready for trusted publishing

### DIFF
--- a/.github/workflows/release-js-passkeys-next-auth-provider.yml
+++ b/.github/workflows/release-js-passkeys-next-auth-provider.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     working-directory: packages/js/passkeys-next-auth-provider
 
+permissions:
+  id-token: write  # Required for OIDC
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -16,12 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.11.1'
           registry-url: 'https://registry.npmjs.org'
       - uses: oven-sh/setup-bun@v1
       - run: bun i
       - run: bun run build
       - name: publish passkeys-next-auth-provider
         run: cd ./dist && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_SECRET }}

--- a/.github/workflows/release-js-passkeys-sdk.yml
+++ b/.github/workflows/release-js-passkeys-sdk.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     working-directory: packages/js/passkeys-sdk
 
+permissions:
+  id-token: write  # Required for OIDC
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -16,12 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.11.1'
           registry-url: 'https://registry.npmjs.org'
       - uses: oven-sh/setup-bun@v1
       - run: bun i
       - run: bun run build
       - name: publish passkeys-sdk
         run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISHING_SECRET }}


### PR DESCRIPTION
# Description

See https://docs.npmjs.com/trusted-publishers#limitations-and-future-improvements

# Notes

- The workflow uses the current LTS version ([v24.11.1](https://nodejs.org/en/download/archive/v24.11.1)) of node, which includes an `npm` version of `v11.6.2`, so a workflow step for updating `npm` as shown in the above documentation should not be necessary.
